### PR TITLE
DHS-2: Adding Nationality page

### DIFF
--- a/omod/src/main/webapp/fragments/field/nationality.gsp
+++ b/omod/src/main/webapp/fragments/field/nationality.gsp
@@ -1,0 +1,13 @@
+<p>
+    <label>
+        ${config.label}
+        <span>(${ ui.message("emr.formValidation.messages.requiredField.label") })</span>
+    </label>
+    <select name="${config.formFieldName}">
+        <option value="">Select One</option>
+        <option value ="165218">National</option>
+        <option value ="1165219">Foreigner</option>
+        <option value ="165220">Refugee</option>
+    </select>
+    <span class="field-error"></span>
+</p>


### PR DESCRIPTION
With this PR,  we had not suggested this however my idea about nationality page is to allow the user to be able to record the nationality of the patient, Forexample whether a patient is a National, Foregner or refugee, 
   i added three features to choose from nationality field and we can only use this as per now after merging this[ Pr here](https://github.com/digitalhealthcaresociety/openmrs-module-registrationapp/pull/1), then we can pull rebase upstream master and be able to view nationality page
   
cc @prapakaransp  @sharvanan 